### PR TITLE
fix duplicate tag

### DIFF
--- a/doc/watchdogs.jax
+++ b/doc/watchdogs.jax
@@ -419,7 +419,7 @@ Example >
 	|:WatchdogsRun| とは違い、不正な設定だった場合にエラー出力が行われませ
 	ん。
 
-:WatchdogsRunSweep				*:WatchdogsRunSilent*
+:WatchdogsRunSweep				*:WatchdogsRunSweep*
 	|watchdogs.vim| を強制終了させます。
 	内部では |quickrun#sweep_sessions()| を呼び出しているだけなので詳しい
 	挙動に関してはそちらを参照して下さい。


### PR DESCRIPTION
タグ重複してたので直しました。
(.vimrcでhelptag生成してるとこの手のエラーはvim起動時に出てくれるのですぐ気付きます)
