### PR TITLE
Add "parse only" to luac.

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -145,7 +145,7 @@ let g:watchdogs#default_config = {
 \
 \	"watchdogs_checker/luac" : {
 \		"command" : "luac",
-\		"exec"    : "%c %o %s:p",
+\		"exec"    : "%c %o -p %s:p",
 \		"quickfix/errorformat" : '%.%#: %#%f:%l: %m',
 \	},
 \


### PR DESCRIPTION
`watchdogs_checker/luac`にて`-p`(parse only)オプションが無い為に`luac.out`が出力されていたのを修正しました
