### PR TITLE
Add typescript.

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -99,6 +99,15 @@ let g:watchdogs#default_config = {
 \		"exec"      : "%c /Zs %o %s:p ",
 \	},
 \
+\   "watchdogs_checker/tsc" : {
+\	    "command" : "tsc",
+\	    "exec"    : "%c %s:p",
+\	    "quickfix/errorformat" : '%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m',
+\   },
+\
+\   "typescript/watchdogs_checker" : {
+\	    "type" : "watchdogs_checker/tsc"
+\   },
 \
 \	"coffee/watchdogs_checker" : {
 \		"type"

--- a/doc/watchdogs.jax
+++ b/doc/watchdogs.jax
@@ -194,8 +194,11 @@
 - "scss"
   sass で --check オプションで scss のシンタックスチェックを行います。
 
-- "coffee"
-  coffee の -c -l オプションで coffee のシンタックスチェックを行います。
+- "typescript"
+  tsc で typescript のシンタックスチェックを行います。
+
+- "cofee"
+  coffee の -c -l オプションで cofeee のシンタックスチェックを行います。
 
 - "coffeelint"
   coffeelint で coffee のシンタックスチェックを行います。
@@ -260,6 +263,9 @@
 
 - "scss"
   デフォルト : "watchdogs_checker/scss"
+
+- "typescript"
+  デフォルト : "watchdogs_checker/tsc"
 
 - "coffee"
   デフォルト : "watchdogs_checker/coffee"


### PR DESCRIPTION
デフォルトでtypescriptをサポートするようにautoload/watchdogs.vimに追加しました。
typescriptはjavascriptへの変換系言語の一つです

http://www.typescriptlang.org/
