### PR TITLE
bugfix tsc errorformat

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -109,7 +109,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/tsc" : {
 \		"command" : "tsc",
 \		"exec"	: "%c %s:p",
-\		"quickfix/errorformat" : '%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m',
+\		"quickfix/errorformat" : '%+A\ %#%f\ %#(%l\\,%c):\ %m,%C%m',
 \	},
 \
 \


### PR DESCRIPTION
たびたびのpull-request、すみません。
自分のvimrcから移すしたときに囲みをシングルクォートにしたのを失念してました。
testしたつもりでしたが、自分のvimrcの方の設定が動いていたようです。。

今度はvimrcの設定を削除してこちらで動作確認してます。
