### PR TITLE
update errorformat for vimlint

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -357,7 +357,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/vimlint" : {
 \		'command': 'vim',
 \		"exec" : '%C -N -u NONE -i NONE -V1 -e -s -c "set rtp+=' . s:get_vimlparser_plugin_dir() . ',' . s:get_vimlint_syngan_plugin_dir() . '" -c "call vimlint#vimlint(''%s'', {})" -c "qall!"',
-\		'errorformat': '%f:%l:%c:%m',
+\		'errorformat': '%f:%l:%c:%trror: %m,%f:%l:%c:%tarning: %m,%f:%l:%c:%m',
 \	 },
 \
 \	"watchdogs_checker/vimlint_by_dbakker" : {


### PR DESCRIPTION
vimlint の出力形式を変更したので errorformat を更新しました。
取り込みお願いいたします。
