### PR TITLE
Add "parse only" option to scalac

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -346,7 +346,7 @@ let g:watchdogs#default_config = {
 \
 \	"watchdogs_checker/scalac" : {
 \		"command" : "scalac",
-\		"exec"    : "%c %o %s:p",
+\		"exec"    : "%c %o -Ystop-after:parser %s:p",
 \		"errorformat"    : '%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,%-G%.%#',
 \	 },
 \


### PR DESCRIPTION
scalacでコンパイルが通るとclassファイルが生成されるので -Ystop-after:parser オプションを使ってパースだけ行うようにしました。
