### PR TITLE
Fix default configuration for flake8

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -274,7 +274,7 @@ let g:watchdogs#default_config = {
 \	"python/watchdogs_checker" : {
 \		"type"
 \			: executable("pyflakes") ? "watchdogs_checker/pyflakes"
-\			: executable("flake8") ? "watchdogs_checker/pyflakes"
+\			: executable("flake8") ? "watchdogs_checker/flake8"
 \			: ""
 \	},
 \	
@@ -287,7 +287,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/flake8" : {
 \		"command" : "flake8",
 \		"exec"    : '%c %o %s:p',
-\		"errorformat" : '%f:%l:%m',
+\		"errorformat" : '%f:%l:%c: %m',
 \	},
 \
 \	"ruby/watchdogs_checker" : {


### PR DESCRIPTION
Pythonのデフォルト設定でpyflakesがなくてもflake8が有効にならないところとflake8のerrorformatを修正しました。
