### PR TITLE
Remove hlint option from ghc-mod

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -199,7 +199,7 @@ let g:watchdogs#default_config = {
 \
 \	"watchdogs_checker/ghc-mod" : {
 \		"command" : "ghc-mod",
-\		"exec"    : '%c %o --hlintOpt="--language=XmlSyntax" check %s:p',
+\		"exec"    : '%c %o check %s:p',
 \	},
 \
 \	"watchdogs_checker/hlint" : {


### PR DESCRIPTION
This is no longer needed. (maybe)

See syntastic's similar commit (https://github.com/scrooloose/syntastic/commit/fa0ef8427dcd56f1f067ccc1f3b818308321c2a5)
