### PR TITLE
disable X11 on vimlint

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -410,7 +410,7 @@ let g:watchdogs#default_config = {
 \
 \	"watchdogs_checker/vimlint" : {
 \		'command': 'vim',
-\		"exec" : '%C -N -u NONE -i NONE -V1 -e -s -c "set rtp+=' . s:get_vimlparser_plugin_dir() . ',' . s:get_vimlint_syngan_plugin_dir() . '" -c "call vimlint#vimlint(''%s'', %{ exists(''g:vimlint#config'') ? string(g:vimlint#config) : g:watchdogs#vimlint_empty_config })" -c "qall!"',
+\		"exec" : '%C -X -N -u NONE -i NONE -V1 -e -s -c "set rtp+=' . s:get_vimlparser_plugin_dir() . ',' . s:get_vimlint_syngan_plugin_dir() . '" -c "call vimlint#vimlint(''%s'', %{ exists(''g:vimlint#config'') ? string(g:vimlint#config) : g:watchdogs#vimlint_empty_config })" -c "qall!"',
 \		'errorformat': '%f:%l:%c:%trror: %m,%f:%l:%c:%tarning: %m,%f:%l:%c:%m',
 \	 },
 \


### PR DESCRIPTION
`$DISPLAY` 環境変数がある場合、vimlint 実行中に X サーバーへの接続(エラー)メッセージが出てしまう。
起動オプション `-X` を追加。