### PR TITLE
Revert errorformat of jshint.

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -244,7 +244,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/jshint" : {
 \		"command" : "jshint",
 \		"exec"    : "%c %o %s:p",
-\		"errorformat" : '%tarning: %m,%-G%*\d error,%-G%*\d warnings,%f:%l: %trror: %m,%f:%l: %tarning: %m,%+G%.%#',
+\		"errorformat" : '%f: line %l\,\ col %c\, %m',
 \	},
 \
 \


### PR DESCRIPTION
9e6bfc1d17a09a9f5d2d1db045fb403cf5b38e04 で JSON の checker が追加されていますが、その時に `jshint` の `errorformat` も変更されています。
しかし、この `errorformat` だと手元では正常に動作しませんでした。
一つ上の `javac` の `errorformat` と全く同一なため、コピペミスだと思い修正しました