### PR TITLE
Add vint

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -423,10 +423,16 @@ let g:watchdogs#default_config = {
 \
 \	"vim/watchdogs_checker" : {
 \		"type"
+\			: executable("vint") ? "watchdogs_checker/vint"
 \			: s:executable_vim_vimlint() ? "watchdogs_checker/vimlint"
 \			: s:executable_vimlint() ? "watchdogs_checker/vimlint_by_dbakker"
 \			: ""
 \	},
+\
+\	"watchdogs_checker/vint" : {
+\		'command': 'vint',
+\		"exec" : '%c %s',
+\	 },
 \
 \	"watchdogs_checker/vimlint" : {
 \		'command': 'vim',


### PR DESCRIPTION
[vint](https://github.com/Kuniwak/vint) に対応させてみました。
プラグインによってはエラーがかなり出てハイライトとかしてるとすごいことになるケースもあるので、ひとまず入れて大丈夫かどうか判断お願いします。

↓の画像は autoload/watchdocs.vim でエラーをハイライトさせてみた結果です。
![2015-04-16_17h25_18](https://cloud.githubusercontent.com/assets/1257633/7177002/4bd19d80-e45e-11e4-9366-dd57fc660fc7.gif)
