### PR TITLE
Support phpcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Async syntax check plugin.
  * vimparse.pl
 * PHP
  * php
+ * phpcs
 * Python
  * pyflakes
  * flake8

--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -339,6 +339,7 @@ let g:watchdogs#default_config = {
 \	"php/watchdogs_checker" : {
 \		"type"
 \			: executable("php") ? "watchdogs_checker/php"
+\			: executable("phpcs") ? "watchdogs_checker/phpcs"
 \			: ""
 \	},
 \
@@ -346,6 +347,12 @@ let g:watchdogs#default_config = {
 \		"command" : "php",
 \		"exec"    : "%c %o -l %s:p",
 \		"errorformat" : '%m\ in\ %f\ on\ line\ %l',
+\	},
+\
+\	"watchdogs_checker/phpcs" : {
+\		"command" : "phpcs",
+\		"exec"    : "%c --report=emacs %o %s:p",
+\		"errorformat" : '%f:%l:%c:\ %m',
 \	},
 \
 \

--- a/doc/watchdogs.jax
+++ b/doc/watchdogs.jax
@@ -182,6 +182,10 @@
 - "php"
   php の -l オプションで php のシンタックスチェックを行います。
 
+- "phpcs"
+  PHP_CodeSniffer の --report=emacs オプションで php のシンタックスチェックを行います。
+  squizlabs/PHP_CodeSniffer - https://github.com/squizlabs/PHP_CodeSniffer
+
 - "luac"
   luac を使用した lua のシンタックスチェックを行います。
 


### PR DESCRIPTION
PHP_CodeSnifferのサポートを追加しました。
https://github.com/squizlabs/PHP_CodeSniffer

出力フォーマットはemacsのものを利用しています。
https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-an-emacs-report