### PR TITLE
Fix errorformat for eslint

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -270,7 +270,8 @@ let g:watchdogs#default_config = {
 \		"command" : "eslint",
 \		"exec"    : "%c -f compact %o %s:p",
 \		"errorformat" : '%E%f: line %l\, col %c\, Error - %m,' .
-\						'%W%f: line %l\, col %c\, Warning - %m',
+\						'%W%f: line %l\, col %c\, Warning - %m,' .
+\						'%-G%.%#',
 \	},
 \
 \	"json/watchdogs_checker" : {


### PR DESCRIPTION
Issue立ててないのですが、eslintのエラーリストが崩れていたので修正しました

before
![screenshot from 2015-12-23 22-35-45](https://cloud.githubusercontent.com/assets/2123378/11977549/1e783694-a9c7-11e5-9ccd-ab70dd876a06.png)

after
![screenshot from 2015-12-23 22-48-09](https://cloud.githubusercontent.com/assets/2123378/11977565/46777484-a9c7-11e5-852c-7eb4c4890853.png)
