### PR TITLE
Support phpmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Async syntax check plugin.
 * PHP
  * php
  * phpcs
+ * phpmd
 * Python
  * pyflakes
  * flake8

--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -356,6 +356,7 @@ let g:watchdogs#default_config = {
 \		"type"
 \			: executable("php") ? "watchdogs_checker/php"
 \			: executable("phpcs") ? "watchdogs_checker/phpcs"
+\			: executable("phpmd") ? "watchdogs_checker/phpmd"
 \			: ""
 \	},
 \
@@ -369,6 +370,13 @@ let g:watchdogs#default_config = {
 \		"command" : "phpcs",
 \		"exec"    : "%c --report=emacs %o %s:p",
 \		"errorformat" : '%f:%l:%c:\ %m',
+\	},
+\
+\	"watchdogs_checker/phpmd" : {
+\		"command" : "phpmd",
+\		"exec"    : "%c %s:p text %o",
+\		"cmdopt"  : "codesize,design,unusedcode,naming",
+\		"errorformat" : '%f:%l%\s%m,%-G%.%#',
 \	},
 \
 \

--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -375,7 +375,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/phpmd" : {
 \		"command" : "phpmd",
 \		"exec"    : "%c %s:p text %o",
-\		"cmdopt"  : "codesize,design,unusedcode,naming",
+\		"cmdopt"  : "cleancode,codesize,design,naming,unusedcode",
 \		"errorformat" : '%f:%l%\s%m,%-G%.%#',
 \	},
 \

--- a/doc/watchdogs.jax
+++ b/doc/watchdogs.jax
@@ -186,6 +186,10 @@
   PHP_CodeSniffer の --report=emacs オプションで php のシンタックスチェックを行います。
   squizlabs/PHP_CodeSniffer - https://github.com/squizlabs/PHP_CodeSniffer
 
+- "phpmd"
+  PHP Mess Detector の cleancode,codesize,design,naming,unusedcode オプションで php のシンタックスチェックを行います。
+  phpmd/phpmd - https://github.com/phpmd/phpmd
+
 - "luac"
   luac を使用した lua のシンタックスチェックを行います。
 


### PR DESCRIPTION
PHP Mess Detectorを追加しました。
http://phpmd.org/http://phpmd.org

phpmdは明示的にrulesetを指定する必要がある為、 `cmdopt` を指定しています。
defaultの `cmdopt` は標準rulesetの内の, phpmd開発者自身が賛否両論なrulesetとしているもの以外を指定しています。
http://phpmd.org/rules/index.html