### PR TITLE
Prioritize flake8 over pyflakes

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -398,8 +398,8 @@ let g:watchdogs#default_config = {
 \
 \	"python/watchdogs_checker" : {
 \		"type"
-\			: executable("pyflakes") ? "watchdogs_checker/pyflakes"
 \			: executable("flake8") ? "watchdogs_checker/flake8"
+\			: executable("pyflakes") ? "watchdogs_checker/pyflakes"
 \			: ""
 \	},
 \


### PR DESCRIPTION
flake8 は pyflakes に依存しているので、flake8 がある場合は、そちらを優先した方が良いのではないかと思います。