### PR TITLE
Add rust support (rustc)

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -432,6 +432,22 @@ let g:watchdogs#default_config = {
 \		"errorformat" : '%f:%l:%c:%m',
 \	},
 \
+\	"rust/watchdogs_checker" : {
+\		"type"
+\			: executable("rustc") ? "watchdogs_checker/rustc"
+\			: ""
+\	},
+\
+\	"watchdogs_checker/rustc" : {
+\		"command" : "rustc",
+\		"exec"    : '%c %o %s:p',
+\		"cmdopt" : "-Z parse-only",
+\		"errorformat"
+\			: '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m'
+\			. ',%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m'
+\			. ',%C%f:%l %m'
+\			. ',%-Z%.%#',
+\	},
 \
 \	"sass/watchdogs_checker" : {
 \		"type"


### PR DESCRIPTION
Rustのチェッカーがなかったので追加しました。
コンパイラ（rustc）だけで動作します。
手元では stable (1.9.0) と nightly (1.11.0-nightly) で動作確認しました。

errorformatは[syntasticの古いバージョン（WTFPL）](https://github.com/scrooloose/syntastic/blob/3.4.0/syntax_checkers/rust/rustc.vim)から拝借しました。
