### PR TITLE
Fix scss-lint errorformat

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -269,7 +269,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/jshint" : {
 \		"command" : "jshint",
 \		"exec"    : "%c %o %s:p",
-\		"errorformat" : '%f: line %l\,\ col %c\, %m,%-G%.%#',
+\		"errorformat" : '%f: line %l\,\ col %c\, %m, %-G%.%#',
 \	},
 \
 \	"watchdogs_checker/eslint" : {

--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -482,7 +482,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/scss-lint" : {
 \		"command" : "scss-lint",
 \		"exec"    : "%c %o %s:p",
-\		"errorformat" : '%f:%l\ %m',
+\		"errorformat" : '%f:%l\ %m, %-G%.%#',
 \	},
 \
 \


### PR DESCRIPTION
以前PR( #42 )したscss-lintに不要な空行が出力されていたのでerrorformatを修正しました。

#39, #44 と同様です。