### PR TITLE
Fix rubocop errformat

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -443,7 +443,7 @@ let g:watchdogs#default_config = {
 \	"watchdogs_checker/rubocop" : {
 \		"command" : "rubocop",
 \		"exec"    : "%c %o %s:p",
-\		"errorformat" : '%f:%l:%c:%m',
+\		"errorformat" : '%f:%l:%c:%m, %-G%.%#',
 \	},
 \
 \	"rust/watchdogs_checker" : {


### PR DESCRIPTION
rubocopのerrformatも修正しました。
#39, #44, #50 と同様です。

## before

![screen shot 2016-12-20 at 18 27 18](https://cloud.githubusercontent.com/assets/12206768/21345099/253a77d8-c6e2-11e6-9dbf-c470f005d37f.png)


## after

![screen shot 2016-12-20 at 18 29 28](https://cloud.githubusercontent.com/assets/12206768/21345152/552767e4-c6e2-11e6-93f9-6377b75900f2.png)
