### PR TITLE
Add `--noEmit` to `watchdogs_checker/tsc`.

### DIFF
--- a/autoload/watchdogs.vim
+++ b/autoload/watchdogs.vim
@@ -115,7 +115,7 @@ let g:watchdogs#default_config = {
 \
 \	"watchdogs_checker/tsc" : {
 \		"command" : "tsc",
-\		"exec"	: "%c %s:p",
+\		"exec"	: "%c --noEmit %o %s:p",
 \		"errorformat" : '%+A\ %#%f\ %#(%l\\,%c):\ %m,%C%m',
 \	},
 \


### PR DESCRIPTION
Do not emit outputs when checking.